### PR TITLE
refactor: Update did-comm-go references to aries-framework-go

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@
 #
 
 service:
-  project-path: github.com/trustbloc/did-comm-go
+  project-path: github.com/trustbloc/aries-framework-go
   golangci-lint-version: 1.16.x
   prepare:
     - GO111MODULE=on go mod vendor

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ unit-test: generate-test-keys
 generate-test-keys: clean
 	@mkdir -p -p test/fixtures/keys/tls
 	@docker run -i --rm \
-		-v $(abspath .):/opt/go/src/github.com/trustbloc/did-comm-go \
-		--entrypoint "/opt/go/src/github.com/trustbloc/did-comm-go/scripts/generate_test_keys.sh" \
+		-v $(abspath .):/opt/go/src/github.com/trustbloc/aries-framework-go \
+		--entrypoint "/opt/go/src/github.com/trustbloc/aries-framework-go/scripts/generate_test_keys.sh" \
 		frapsoft/openssl
 
 clean:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-[![Release](https://img.shields.io/github/release/trustbloc/did-comm-go.svg?style=flat-square)](https://github.com/trustbloc/did-comm-go/releases/latest)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://raw.githubusercontent.com/trustbloc/did-comm-go/master/LICENSE)
+[![Release](https://img.shields.io/github/release/trustbloc/aries-framework-go.svg?style=flat-square)](https://github.com/trustbloc/aries-framework-go/releases/latest)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://raw.githubusercontent.com/trustbloc/aries-framework-go/master/LICENSE)
 
-[![Build Status](https://travis-ci.com/trustbloc/did-comm-go.svg?branch=master)](https://travis-ci.com/trustbloc/did-comm-go)
-[![GolangCI](https://golangci.com/badges/github.com/trustbloc/did-comm-go.svg)](https://golangci.com/r/github.com/trustbloc/did-comm-go)
-[![codecov](https://codecov.io/gh/trustbloc/did-comm-go/branch/master/graph/badge.svg)](https://codecov.io/gh/trustbloc/did-comm-go)
-[![Go Report Card](https://goreportcard.com/badge/github.com/trustbloc/did-comm-go?style=flat-square)](https://goreportcard.com/report/github.com/trustbloc/did-comm-go)
-[![codebeat badge](https://codebeat.co/badges/71491572-8383-4334-979f-1e2052d20f65)](https://codebeat.co/projects/github-com-trustbloc-did-comm-go-master)
+[![Build Status](https://travis-ci.com/trustbloc/aries-framework-go.svg?branch=master)](https://travis-ci.com/trustbloc/aries-framework-go)
+[![GolangCI](https://golangci.com/badges/github.com/trustbloc/aries-framework-go.svg)](https://golangci.com/r/github.com/trustbloc/aries-framework-go)
+[![codecov](https://codecov.io/gh/trustbloc/aries-framework-go/branch/master/graph/badge.svg)](https://codecov.io/gh/trustbloc/aries-framework-go)
+[![Go Report Card](https://goreportcard.com/badge/github.com/trustbloc/aries-framework-go?style=flat-square)](https://goreportcard.com/report/github.com/trustbloc/aries-framework-go)
+[![codebeat badge](https://codebeat.co/badges/a31b0252-0d60-42b8-807f-92bf15a3b9a3)](https://codebeat.co/projects/github-com-trustbloc-agent-framework-go-master)
 
-# did-comm-go
+# aries-framework-go
 
 
 ## Contributing

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-module github.com/trustbloc/did-comm-go
+module github.com/trustbloc/aries-framework-go
 
 require (
 	github.com/pkg/errors v0.8.1

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -11,8 +11,8 @@ import (
 	"encoding/json"
 
 	"github.com/pkg/errors"
-	"github.com/trustbloc/did-comm-go/pkg/models/didexchange"
-	"github.com/trustbloc/did-comm-go/pkg/transport"
+	"github.com/trustbloc/aries-framework-go/pkg/models/didexchange"
+	"github.com/trustbloc/aries-framework-go/pkg/transport"
 )
 
 const (

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -14,8 +14,8 @@ import (
 	"log"
 
 	"github.com/stretchr/testify/require"
-	"github.com/trustbloc/did-comm-go/pkg/models/didexchange"
-	httptransport "github.com/trustbloc/did-comm-go/pkg/transport/http"
+	"github.com/trustbloc/aries-framework-go/pkg/models/didexchange"
+	httptransport "github.com/trustbloc/aries-framework-go/pkg/transport/http"
 )
 
 const certPrefix = "../../test/fixtures/keys/"

--- a/pkg/did/core/provider/basic/did_basic_provider.go
+++ b/pkg/did/core/provider/basic/did_basic_provider.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	didprovider "github.com/trustbloc/did-comm-go/pkg/did/core/provider"
+	didprovider "github.com/trustbloc/aries-framework-go/pkg/did/core/provider"
 )
 
 // Provider provider structure

--- a/pkg/transport/http/http_transport.go
+++ b/pkg/transport/http/http_transport.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	tlsCertPool "github.com/trustbloc/did-comm-go/pkg/transport/http/tls"
+	tlsCertPool "github.com/trustbloc/aries-framework-go/pkg/transport/http/tls"
 )
 
 const commContentType = "application/didcomm-envelope-enc"

--- a/scripts/check_lint.sh
+++ b/scripts/check_lint.sh
@@ -11,6 +11,6 @@ DOCKER_CMD=docker
 
 echo "GolangCI Linter :: Started"
 
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/goapp -e RUN=1 -e REPO=github.com/trustbloc/did-comm-go golangci/build-runner goenvbuild
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/goapp -e RUN=1 -e REPO=github.com/trustbloc/aries-framework-go golangci/build-runner goenvbuild
 
 echo "GolangCI Linter :: Completed"

--- a/scripts/check_unit.sh
+++ b/scripts/check_unit.sh
@@ -7,7 +7,7 @@
 set -e
 
 # Packages to exclude
-PKGS=`go list github.com/trustbloc/did-comm-go/... 2> /dev/null | \
+PKGS=`go list github.com/trustbloc/aries-framework-go/... 2> /dev/null | \
                                                  grep -v /mocks | \
                                                  grep -v /protos`
 

--- a/scripts/generate_test_keys.sh
+++ b/scripts/generate_test_keys.sh
@@ -7,8 +7,8 @@
 
 set -e
 
-echo "Generating DidComm-go Test PKI"
-cd /opt/go/src/github.com/trustbloc/did-comm-go
+echo "Generating aries-framework-go Test PKI"
+cd /opt/go/src/github.com/trustbloc/aries-framework-go
 mkdir -p test/fixtures/keys/tls
 
 cp /etc/ssl/openssl.cnf test/fixtures/keys/openssl.cnf
@@ -20,7 +20,7 @@ openssl req -new -x509 -key test/fixtures/keys/tls/ec-cakey.pem -subj "/C=CA/ST=
 
 #create TLS creds
 openssl ecparam -name prime256v1 -genkey -noout -out test/fixtures/keys/tls/ec-key.pem
-openssl req -new -key test/fixtures/keys/tls/ec-key.pem -subj "/C=CA/ST=ON/O=Example Inc.:DidComm-go/OU=DidComm-go/CN=*.example.com" -reqexts SAN -config test/fixtures/keys/openssl.cnf -out test/fixtures/keys/tls/ec-key.csr
+openssl req -new -key test/fixtures/keys/tls/ec-key.pem -subj "/C=CA/ST=ON/O=Example Inc.:aries-framework-go/OU=aries-framework-go/CN=*.example.com" -reqexts SAN -config test/fixtures/keys/openssl.cnf -out test/fixtures/keys/tls/ec-key.csr
 openssl x509 -req -in test/fixtures/keys/tls/ec-key.csr -extensions SAN -extfile test/fixtures/keys/openssl.cnf -CA test/fixtures/keys/tls/ec-cacert.pem -CAkey test/fixtures/keys/tls/ec-cakey.pem -CAcreateserial -out test/fixtures/keys/tls/ec-pubCert.pem -days 365
 
 #create CA for other creds
@@ -29,18 +29,18 @@ openssl req -new -x509 -key test/fixtures/keys/ec-cakey.pem -subj "/C=CA/ST=ON/O
 
 #create creds 1
 openssl ecparam -name prime256v1 -genkey -noout -out test/fixtures/keys/ec-key1.pem
-openssl req -new -key test/fixtures/keys/ec-key1.pem -subj "/C=CA/ST=ON/O=Example Inc.:DidComm-go/OU=DidComm-go/CN=*.example.com" -reqexts SAN -config test/fixtures/keys/openssl.cnf -out test/fixtures/keys/ec-key1.csr
+openssl req -new -key test/fixtures/keys/ec-key1.pem -subj "/C=CA/ST=ON/O=Example Inc.:aries-framework-go/OU=aries-framework-go/CN=*.example.com" -reqexts SAN -config test/fixtures/keys/openssl.cnf -out test/fixtures/keys/ec-key1.csr
 openssl x509 -req -in test/fixtures/keys/ec-key1.csr -extensions SAN -extfile test/fixtures/keys/openssl.cnf -CA test/fixtures/keys/ec-cacert.pem -CAkey test/fixtures/keys/ec-cakey.pem -CAcreateserial -out test/fixtures/keys/ec-pubCert1.pem -days 365
 
 #create creds 2
 openssl ecparam -name prime256v1 -genkey -noout -out test/fixtures/keys/ec-key2.pem
-openssl req -new -key test/fixtures/keys/ec-key2.pem -subj "/C=CA/ST=ON/O=Example Inc.:DidComm-go/OU=DidComm-go/CN=*.example.com" -reqexts SAN -config test/fixtures/keys/openssl.cnf -out test/fixtures/keys/ec-key2.csr
+openssl req -new -key test/fixtures/keys/ec-key2.pem -subj "/C=CA/ST=ON/O=Example Inc.:aries-framework-go/OU=aries-framework-go/CN=*.example.com" -reqexts SAN -config test/fixtures/keys/openssl.cnf -out test/fixtures/keys/ec-key2.csr
 openssl x509 -req -in test/fixtures/keys/ec-key2.csr -extensions SAN -extfile test/fixtures/keys/openssl.cnf -CA test/fixtures/keys/ec-cacert.pem -CAkey test/fixtures/keys/ec-cakey.pem -CAcreateserial -out test/fixtures/keys/ec-pubCert2.pem -days 365
 
 #create creds 3
 openssl ecparam -name prime256v1 -genkey -noout -out test/fixtures/keys/ec-key3.pem
-openssl req -new -key test/fixtures/keys/ec-key3.pem -subj "/C=CA/ST=ON/O=Example Inc.:DidComm-go/OU=DidComm-go/CN=*.example.com" -reqexts SAN -config test/fixtures/keys/openssl.cnf -out test/fixtures/keys/ec-key3.csr
+openssl req -new -key test/fixtures/keys/ec-key3.pem -subj "/C=CA/ST=ON/O=Example Inc.:aries-framework-go/OU=aries-framework-go/CN=*.example.com" -reqexts SAN -config test/fixtures/keys/openssl.cnf -out test/fixtures/keys/ec-key3.csr
 openssl x509 -req -in test/fixtures/keys/ec-key3.csr -extensions SAN -extfile test/fixtures/keys/openssl.cnf -CA test/fixtures/keys/ec-cacert.pem -CAkey test/fixtures/keys/ec-cakey.pem -CAcreateserial -out test/fixtures/keys/ec-pubCert3.pem -days 365
 
 rm test/fixtures/keys/openssl.cnf
-echo "done generating DidComm-go PKI"
+echo "done generating aries-framework-go PKI"


### PR DESCRIPTION
Aries spec implementation was divided into did-comm-go and agent-framework-go repos in https://github.com/trustbloc. Going forward these will be part of one repo and as such, the did-comm-go repo was renamed into aries-framework-go. The codebase references need to be updated to be in sync with the repo name change.

Closes #27

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>