### PR TITLE
test: Mock Outbound Transport provider

### DIFF
--- a/pkg/introduction/introduction_test.go
+++ b/pkg/introduction/introduction_test.go
@@ -9,101 +9,89 @@ package introduction
 import (
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	mock "github.com/trustbloc/aries-framework-go/pkg/mocks"
 	"github.com/trustbloc/aries-framework-go/pkg/models/didexchange"
 )
 
 const destinationURL = "https://localhost:8090"
-
-/*---------------Mock setup-----------------------*/
-// MockOutboundTransport mock transport (implements OutboundTransport)
-type MockOutboundTransport struct {
-}
-
-// NewMockOutboundTransport new MockOutboundTransport instance
-func NewMockOutboundTransport() *MockOutboundTransport {
-	return &MockOutboundTransport{}
-}
-
-// Send implementation of OutboundTransport.Send api
-func (transport *MockOutboundTransport) Send(data string, destination string) (string, error) {
-	if data == "" || destination == "" {
-		return "", errors.New("Data or destination can't be empty")
-	}
-
-	return "success", nil
-}
+const successResponse = "success"
 
 /*---------------Test-----------------------*/
 func TestSendProposal(t *testing.T) {
+	transport := mock.NewOutboundTransport(successResponse)
+
 	proposal := &didexchange.IntroductionProposal{
 		ID: "aosjfl341kd45",
 		To: &didexchange.IntroductionDescriptor{Name: "Bob"},
 	}
 
 	// positive case
-	require.NoError(t, SendProposal(proposal, destinationURL, NewMockOutboundTransport()))
+	require.NoError(t, SendProposal(proposal, destinationURL, transport))
 
 	// nil proposal
-	require.Error(t, SendProposal(nil, destinationURL, NewMockOutboundTransport()))
+	require.Error(t, SendProposal(nil, destinationURL, transport))
 
 	// nil destination
-	require.Error(t, SendProposal(proposal, "", NewMockOutboundTransport()))
+	require.Error(t, SendProposal(proposal, "", transport))
 
 	// nil Descriptor
 	proposal.To = nil
-	require.Error(t, SendProposal(proposal, destinationURL, NewMockOutboundTransport()))
+	require.Error(t, SendProposal(proposal, destinationURL, transport))
 
 	// nil name inside the Descriptor
 	proposal.To = &didexchange.IntroductionDescriptor{}
-	require.Error(t, SendProposal(proposal, destinationURL, NewMockOutboundTransport()))
+	require.Error(t, SendProposal(proposal, destinationURL, transport))
 }
 
 func TestSendRequest(t *testing.T) {
+	transport := mock.NewOutboundTransport(successResponse)
+
 	request := &didexchange.IntroductionRequest{
 		ID:          "aosjfl341kd45",
 		IntroduceTo: &didexchange.RequestDescriptor{Name: "Bob"},
 	}
 
 	// positive case
-	require.NoError(t, SendRequest(request, destinationURL, NewMockOutboundTransport()))
+	require.NoError(t, SendRequest(request, destinationURL, transport))
 
 	// nil request
-	require.Error(t, SendRequest(nil, destinationURL, NewMockOutboundTransport()))
+	require.Error(t, SendRequest(nil, destinationURL, transport))
 
 	// nil destination
-	require.Error(t, SendRequest(request, "", NewMockOutboundTransport()))
+	require.Error(t, SendRequest(request, "", transport))
 
 	// nil IntroduceTo
 	request.IntroduceTo = nil
-	require.Error(t, SendRequest(request, destinationURL, NewMockOutboundTransport()))
+	require.Error(t, SendRequest(request, destinationURL, transport))
 
 	// nil IntroduceTo name
 	request.IntroduceTo = &didexchange.RequestDescriptor{}
-	require.Error(t, SendRequest(request, destinationURL, NewMockOutboundTransport()))
+	require.Error(t, SendRequest(request, destinationURL, transport))
 }
 
 func TestSendResponse(t *testing.T) {
+	transport := mock.NewOutboundTransport(successResponse)
+
 	response := &didexchange.IntroductionResponse{
 		ID:     "ofjkwfl930or20",
 		Thread: &didexchange.Thread{ID: "aosjfl341kd45"},
 	}
 
 	// positive case
-	require.NoError(t, SendResponse(response, destinationURL, NewMockOutboundTransport()))
+	require.NoError(t, SendResponse(response, destinationURL, transport))
 
 	// nil response
-	require.Error(t, SendResponse(nil, destinationURL, NewMockOutboundTransport()))
+	require.Error(t, SendResponse(nil, destinationURL, transport))
 
 	// nil destination
-	require.Error(t, SendResponse(response, "", NewMockOutboundTransport()))
+	require.Error(t, SendResponse(response, "", transport))
 
 	// nil thread
 	response.Thread = nil
-	require.Error(t, SendResponse(response, destinationURL, NewMockOutboundTransport()))
+	require.Error(t, SendResponse(response, destinationURL, transport))
 
 	// nil thread id
 	response.Thread = &didexchange.Thread{}
-	require.Error(t, SendResponse(response, destinationURL, NewMockOutboundTransport()))
+	require.Error(t, SendResponse(response, destinationURL, transport))
 }

--- a/pkg/mocks/mock_transport.go
+++ b/pkg/mocks/mock_transport.go
@@ -1,0 +1,28 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mock
+
+import "errors"
+
+// OutboundTransport mock outbound transport structure
+type OutboundTransport struct {
+	ExpectedResponse string
+}
+
+// NewOutboundTransport new OutboundTransport instance
+func NewOutboundTransport(expectedResponse string) *OutboundTransport {
+	return &OutboundTransport{ExpectedResponse: expectedResponse}
+}
+
+// Send implementation of OutboundTransport.Send api
+func (transport *OutboundTransport) Send(data string, destination string) (string, error) {
+	if data == "" || destination == "" {
+		return "", errors.New("Data or destination can't be empty")
+	}
+
+	return transport.ExpectedResponse, nil
+}


### PR DESCRIPTION
Currently, the connection module uses real HTTP transport in unit tests. This should be changed to a mock transport. The introduction module client APIs uses mock transport provider defined in its own test file. Need to move this mock transport to a common place and refactor the unit tests to use this mock transport provider.

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>