### PR TITLE
ci: GolangCI Lint - Update docker image source

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   checks:
     docker:
-      - image: golangci/build-runner
+      - image: golangci/golangci-lint:v1.16.0
     environment:
       - REPO: github.com/trustbloc/aries-framework-go
       - RUN: 1
@@ -14,7 +14,7 @@ jobs:
     steps:
       - checkout
       - run: make checks
-      - run: goenvbuild
+      - run: golangci-lint run
   unit-test:
     docker:
       - image: circleci/golang:1.12

--- a/scripts/check_lint.sh
+++ b/scripts/check_lint.sh
@@ -8,6 +8,7 @@
 set -e
 
 DOCKER_CMD=${DOCKER_CMD:-docker}
+GOLANGCI_LINT_VERSION=v1.16.0
 
 if [ ! $(command -v ${DOCKER_CMD}) ]; then
     exit 0
@@ -15,6 +16,6 @@ fi
 
 echo "GolangCI Linter :: Started"
 
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/goapp -e RUN=1 -e REPO=github.com/trustbloc/aries-framework-go golangci/build-runner goenvbuild
+${DOCKER_CMD} run -v $(pwd):/opt/workspace -w /opt/workspace golangci/golangci-lint:${GOLANGCI_LINT_VERSION} golangci-lint run
 
 echo "GolangCI Linter :: Completed"


### PR DESCRIPTION
Currently, the golangci-lint logs the error messages and exists with code 1, but it doesn't stop the overall make target and continues with next one. The issue started with the newer update of golangci build runner docker image (https://hub.docker.com/r/golangci/build-runner/tags - updated 14 days ago). Updated project to use golangci/golangci-lint image.

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>